### PR TITLE
Fixed field bit shift

### DIFF
--- a/RC5.cpp
+++ b/RC5.cpp
@@ -157,7 +157,7 @@ bool RC5::read(unsigned char *toggle, unsigned char *address, unsigned char *com
         // Support for extended RC5:
         // to get extended command, invert S2 and shift into command's 7th bit
         unsigned char extended;
-        extended = (~message & S2_MASK) >> (S2_SHIFT - 7);
+        extended = (~message & S2_MASK) >> (S2_SHIFT - 6);
         *command = ((message & COMMAND_MASK) >> COMMAND_SHIFT) | extended;
         
         return true;


### PR DESCRIPTION
To use the second start bit as the seventh command bit, it must be shifted 6 positions to the right and not 5 as before.  